### PR TITLE
enh: change default package to set gcroot for all deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ nix develop #on a large shared machine you might want to run nix --cores=<some n
 the first time you run this it will take a very long time, because it will build most of the software universe from
 scratch for you, including pytorch and tensorflow, let it run overnight. But after that all subsequent calls
 to nix develop will drop you into your shiny new environment. If you're ready to package up your environment into
-a container you can run
+a container you can run:
+
+```sh
+nix build .#container
+```
+
+this takes a bit of time, so maybe start it before your next meeting.
+
+And if you want to protect the packages in your environment from garbage collection you can
+run:
 
 ```sh
 nix build
 ```
-
-this takes a bit of time, so maybe start it before your next meeting.

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
           path = ./template;
           description = "A flake for medical imaging AI";
         };};
-      defaultPackage = forAllSystems (system: self.packages.${system}.container);
+      defaultPackage = forAllSystems (system: self.devShell.${system});
       defaultTemplate = self.templates.mi-flake;
     };
 }


### PR DESCRIPTION
mkShell generates a text file ./result that includes all the shell dependencies as references so that a gcroot set to the result preserves all the input packages. This needs to be set independently of running nix develop so probably still an interim solution