### PR TITLE
another update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682513551,
-        "narHash": "sha256-W4pR0ab6dElYtihJW8LdM1LR5fm9Mtu0B4Ta9iVjnj8=",
+        "lastModified": 1683040597,
+        "narHash": "sha256-rT6cN7gPnFLkIDytJULDxacGJuPCesfkDg93DLd7N8g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be1e28024612051e1300b1ef7f325831185cad1a",
+        "rev": "b2ab3b0bbbeb5fb53c9d8221dcb2def38482d72c",
         "type": "github"
       },
       "original": {

--- a/src/dependencies.nix
+++ b/src/dependencies.nix
@@ -60,7 +60,7 @@ in
       ];
     })
     (python310.withPackages (ps: with ps; [
-        #accelerate
+        accelerate
         addict
         #apex
         #apiron
@@ -96,7 +96,7 @@ in
         evaluate
         einops
         grad-cam
-        fastai
+        #fastai
         greenlet
         h5py
         heudiconv
@@ -108,9 +108,10 @@ in
         importlib-metadata
         ipykernel
         ipython
-        ipywidgets
+        ipyniivue
         ipympl
         ipyannotations
+        ipywidgets
         superintendent
         nibabel
         nipype
@@ -162,7 +163,7 @@ in
         parso
         PasteDeploy
         pbkdf2
-        #peft
+        peft
         pexpect
         #pfmisc
         pgnotify
@@ -178,10 +179,11 @@ in
         protobuf
         ptyprocess
         pudb
-        #pycm
+        pycm
         pycparser
         pycrypto
         pydicom
+        dicomweb-client
         pynetdicom
         pygments
         pyodbc


### PR DESCRIPTION
- more LLMs: accelerate and peft unbroken
- neuro additions: pydicomweb-client, ipyniivue
- minor upstream updates e.g. gdcm (short) tests enabled
- regressions: fastai not built (as wandb broken)