### PR TITLE
tensorflow: remove

### DIFF
--- a/src/dependencies.nix
+++ b/src/dependencies.nix
@@ -240,7 +240,6 @@ in
         #siuba
         #skorch
         statsmodels
-        tensorflow
         tensorboard
         tensorboardx
         torchvision


### PR DESCRIPTION
See https://github.com/LKS-CHART/medical-imaging-nix/issues/24.

(Also, `fastai` indirectly depends on `tensorflow` but it's currently commented out--willing to patch out tf or just remove fastai, whatever.)