### PR TITLE
python310Packages.tables: remove

### DIFF
--- a/flake/dependencies.nix
+++ b/flake/dependencies.nix
@@ -228,7 +228,7 @@ in
         send2trash
         #slicer
         sqlalchemy
-        tables
+        #tables
         terminado
         terminaltables
         testpath


### PR DESCRIPTION
This packages is rebuilt when cudaSupport is enabled, and running the tests is quite slow.