### PR TITLE
python3.10 -> python3.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695806987,
-        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
+        "lastModified": 1698245295,
+        "narHash": "sha256-yU2VfpoPJ2SkcYXlOlzVK7dgxg4UgHtcovhvvyjB5Zw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
+        "rev": "586212ee7774416c35e2f6fa37c81f72caacc467",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696234590,
-        "narHash": "sha256-mgOzQYTvaTT4bFopVOadlndy2RPwLy60rDjIWOGujwo=",
+        "lastModified": 1695806987,
+        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f902cb49892d300ff15cb237e48aa1cad79d68c3",
+        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
         "type": "github"
       },
       "original": {

--- a/flake/dependencies.nix
+++ b/flake/dependencies.nix
@@ -24,7 +24,7 @@ in
   watch
   openssl
   bashInteractive
-  git gdown git-annex git-lfs datalad dvc
+  git gdown git-annex
   openssh
   less
   which
@@ -36,7 +36,7 @@ in
   parallel
   ruff
   cudaPackages.cudatoolkit
-  snakemake ] ++ glWrappers ++ [
+  ] ++ glWrappers ++ [
   autoGlWrapper
   (emacsWithPackages (ps: with ps; [ magit ess poly-R elpy nix-mode ]))
   (with rPackages;
@@ -105,7 +105,6 @@ in
         fire  # for monai.bundle
         greenlet
         h5py
-        heudiconv
         highdicom
         httplib2
         hupper
@@ -121,7 +120,6 @@ in
         ipywidgets
         superintendent
         nibabel
-        nilearn
         nipype
         antspyx
         iso8601
@@ -172,7 +170,6 @@ in
         pbkdf2
         peft
         pexpect
-        #pfmisc
         pgnotify
         psycopg2
         pickleshare
@@ -180,7 +177,6 @@ in
         pip
         plaster
         plaster-pastedeploy
-        #pretrainedmodels
         prometheus-client
         prompt-toolkit
         protobuf
@@ -228,16 +224,12 @@ in
         scipy
         secretstorage
         send2trash
-        #slicer
         sqlalchemy
-        #tables
         terminado
         terminaltables
         testpath
         text-unidecode
-        plotnine
         polars
-        #pymc
         pydantic
         pyradiomics
         torch
@@ -245,9 +237,6 @@ in
         rising
         simpleitk
         seaborn
-        sentencepiece
-        #siuba
-        #skorch
         statsmodels
         tensorboard
         tensorboardx
@@ -255,7 +244,6 @@ in
         torchmetrics
         timm
         torchio
-        tornado
         tqdm
         traitlets
         transaction
@@ -270,8 +258,6 @@ in
         webencodings
         widgetsnbextension
         wtforms
-        xarray
-        xgboost
         xnatpy
         zipp
     ]))

--- a/flake/dependencies.nix
+++ b/flake/dependencies.nix
@@ -63,7 +63,7 @@ in
         wrapr
       ];
     })
-    (python310.withPackages (ps: with ps; [
+    (python311.withPackages (ps: with ps; [
         accelerate
         addict
         albumentations
@@ -81,7 +81,7 @@ in
         bleach
         bitsandbytes
         bokeh
-        catboost
+        #catboost
         certifi
         cffi
         chardet
@@ -92,7 +92,7 @@ in
         dask
         datasets
         dicom2nifti
-        debugpy
+        #debugpy
         decorator
         defusedxml
         deid
@@ -141,7 +141,7 @@ in
         keyrings-cryptfile
         kiwisolver
         lightgbm
-        llvmlite
+        #llvmlite
         markupsafe
         matplotlib
         mistune

--- a/flake/overlay.nix
+++ b/flake/overlay.nix
@@ -1,5 +1,5 @@
 { orthanc_xnat_tools_src }: final: prev: {
-  python310 = prev.python310.override { packageOverrides = pfinal: pprev: {
+  python311 = prev.python311.override { packageOverrides = pfinal: pprev: {
     bitsandbytes = pprev.bitsandbytes.overrideAttrs (oa: rec {
       version = "0.37.0";
       src = final.fetchFromGitHub {
@@ -52,8 +52,8 @@
       format = "wheel";
 
       src = final.fetchurl {
-        url = "https://files.pythonhosted.org/packages/c8/8f/e031b735a680f290aa00fec0720834f7b4de66ec339096be1913759b9b4a/pillow_jpls-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-        hash = "sha256-0JeRmAGv6wojbyIDbLuuD99pj/l+k1BAhEEjp6P/Syk";
+        url = "https://files.pythonhosted.org/packages/72/f3/725fd022d58e95374c0c6e8e3d183126938ffec580583fa2bf24a453191d/pillow_jpls-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+        hash = "sha256-zpOAh+TPpO4YtleDfHXTtISpa3ibTbq9E7B4k2slhEA=";
       };
 
       propagatedBuildInputs = with pprev; [ pillow ];
@@ -152,12 +152,11 @@
     };
     antspyx = pfinal.buildPythonPackage rec {
       pname = "antspyx";
-      version = "0.3.5";
+      version = "0.3.8";
       src = final.fetchurl {
-        url = "https://files.pythonhosted.org/packages/e8/1c/f324098ce15c330c1adff72b49220cb88815b208485bfb52795f2028100c/antspyx-0.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-        sha256 = "y3LhIBPcQuEDr7GjgJIgSgMWIbX/2CW7ZQ1fwBYaF+k=";
+        url = "https://files.pythonhosted.org/packages/dd/2f/a81d5629ef8e545cffd86368756962682a7386a80601fe35387e4aaffa23/antspyx-0.3.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+        hash = "sha256-q6xozoAph9JZ0naXX4vRbqsj6kldeH9WAe2R4CZDIS0=";
       };
-      # nativeBuildInputs = [ final.patchelf ];
       propagatedBuildInputs = with pfinal; [ matplotlib pyyaml scikitimage scikit-learn chart-studio nibabel statsmodels
                                              webcolors
                                            ];

--- a/flake/overlay.nix
+++ b/flake/overlay.nix
@@ -1,5 +1,8 @@
 { orthanc_xnat_tools_src }: final: prev: {
   python311 = prev.python311.override { packageOverrides = pfinal: pprev: {
+    polars = pprev.polars.overridePythonAttrs (oa: {
+      buildInputs = [ ];  # workaround for https://github.com/NixOS/nixpkgs/issues/263799
+    });
     bitsandbytes = pprev.bitsandbytes.overrideAttrs (oa: rec {
       version = "0.37.0";
       src = final.fetchFromGitHub {


### PR DESCRIPTION
Flake.lock needs another bump, but (~pending open PR to fix pynetdicom tests~[merged]) everything builds with python3.11 except ~debugpy, and~ [fixed], annoyingly, catboost.

This PR might seem superfluous and/or premature but python 3.11 being the default python3 will soon hit master in time for NixOS 23.11, so we need to update or face the usual issue of Python CLI tools breaking the devShells (or hold back Nixpkgs until we make this update, clearly undesirable).