### PR TITLE
tbi-deps-next

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724395761,
-        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
+        "lastModified": 1728249353,
+        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
+        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   # Nixpkgs / NixOS version to use.
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    #nixGL.url = "github:guibou/nixGL";
     nixGL.url = "github:cfhammill/nixGL";
     nixGL.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -31,6 +30,7 @@
       # Nvidia drivers to support
       supportedNvidiaDrivers = [
         "535.154.05"
+        "535.183.06"
       ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.

--- a/flake/dependencies.nix
+++ b/flake/dependencies.nix
@@ -41,7 +41,6 @@ in
   age
   ] ++ glWrappers ++ [
   autoGlWrapper
-  (emacsWithPackages (ps: with ps; [ magit ess poly-R elpy nix-mode ]))
   (python311.withPackages (ps: with ps; [
         avro
         backcall
@@ -51,8 +50,10 @@ in
         deid
         entrypoints
         einops
+        finetuning-scheduler
         grad-cam
-        ignite
+        great-tables
+        ibis-framework
         imageio
         importlib-metadata
         ipykernel
@@ -61,6 +62,7 @@ in
         ipympl
         ipyannotations
         ipywidgets
+        itk
         superintendent
         nibabel
         antspyx
@@ -137,7 +139,9 @@ in
         widgetsnbextension
         xnatpy
         xlrd
-        #ydata-profiling
+        ydata-profiling
         zipp
-    ]))
+      ] ++ ibis-framework.optional-dependencies.postgres
+        ++ ibis-framework.optional-dependencies.duckdb
+        ++ ibis-framework.optional-dependencies.polars))
 ]

--- a/flake/overlay.nix
+++ b/flake/overlay.nix
@@ -1,11 +1,8 @@
 { orthanc_xnat_tools_src }: final: prev: {
   python311 = prev.python311.override { packageOverrides = pfinal: pprev: {
+
     # see https://github.com/NixOS/nixpkgs/issues/252616
     albumentations = pprev.albumentations.overridePythonAttrs (oa: {
-      pythonImportsCheck = [ ];
-    });
-    # see https://github.com/NixOS/nixpkgs/issues/252616
-    qudida = pprev.qudida.overridePythonAttrs (oa: {
       pythonImportsCheck = [ ];
     });
     orthanc-xnat-tools = pfinal.buildPythonPackage rec {


### PR DESCRIPTION
 - flake.nix: add additional supportedNvidiaDrivers
 - flake.lock: bump nixpkgs
 - emacsWithPackages: remove
 - add ITK (bloats the container by ~0.8G uncompressed though)
 - add finetuning-scheduler for pytorch-lightning training experiments
 - add ibis framework and some backend deps (polars, postgres, duckdb)
 - restore ydata-profiling (was temporarily broken)
 - add great-tables (for notebook output formatting)
 - ignite: remove (since we only use pytorch-lightning)