### PR TITLE
mk-docker.nix: use `streamLayeredImage` instead of `buildImage`

### DIFF
--- a/flake/mk-docker.nix
+++ b/flake/mk-docker.nix
@@ -1,13 +1,10 @@
 { pkgs, contents }:
 
-with pkgs;
-with pkgs.dockerTools;
+pkgs.dockerTools.streamLayeredImage {
+  name = "medical-imaging-nix";
+  tag = "latest";
 
-buildImage {
-  name = "test-docker";
-  tag = "test";
   created = "now";
-  copyToRoot = contents;
-  diskSize = 1024*80;
-  buildVMMemorySize = 1024*8;
-}  
+
+  inherit contents;
+}


### PR DESCRIPTION
Don't assemble the image on the Nix side before passing to Docker, saving disk and compute, due to streaming. Due to layering, we should also be able to take advantage of layer caching on the Docker side, saving additional rebuild time. (This also makes it feasible to include the code in the image rather than on disk as we currently do.)

Removed disk and VM memory size options as streamLayeredImage doesn't support these.

Changed the default tag since `test-docker` is somewhat obsolete. Requires a corresponding but straightforward PR to the deployment code.