### PR TITLE
flake.nix: use `self.shortRev` in case the repo is clean

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         system: { 
           docker = import ./flake/mk-docker.nix {pkgs = nixpkgsFor.${system};
                                                  contents = contentsFor.${system};
-                                                 tag = self.dirtyShortRev;
+                                                 tag = self.shortRev or self.dirtyShortRev;
                                                     };
         });
       templates = {


### PR DESCRIPTION
Necessary since dirtyShortRev doesn't exist in that case!?